### PR TITLE
Removals for r5 & Opportunistic Bug Fixes

### DIFF
--- a/backend/src/main/java/com/empire/Army.java
+++ b/backend/src/main/java/com/empire/Army.java
@@ -60,7 +60,7 @@ class Army {
 		if (lastStand) mods += Constants.lastStandMod;
 		if (isArmy() && NationData.getStateReligion(kingdom, w).religion == Religion.IRUHAN) mods += inspires * Constants.perInspireMod;
 		if (leader != Constants.noLeader && Constants.noCaptor.equals(leader.captor)) {
-			mods += leader.calcLevel(isArmy() ? Constants.charDimGeneral : Constants.charDimAdmiral) * Constants.perLevelLeaderMod;
+			mods += isArmy() ? leader.calcArmyLeadMod() : leader.calcNavyLeadMod();
 		}
 
 		return strength * mods;

--- a/backend/src/main/java/com/empire/Army.java
+++ b/backend/src/main/java/com/empire/Army.java
@@ -60,7 +60,7 @@ class Army {
 		if (lastStand) mods += Constants.lastStandMod;
 		if (isArmy() && NationData.getStateReligion(kingdom, w).religion == Religion.IRUHAN) mods += inspires * Constants.perInspireMod;
 		if (leader != Constants.noLeader && Constants.noCaptor.equals(leader.captor)) {
-			mods += isArmy() ? leader.calcArmyLeadMod() : leader.calcNavyLeadMod();
+			mods += leader.calcLeadMod(type);
 		}
 
 		return strength * mods;

--- a/backend/src/main/java/com/empire/Character.java
+++ b/backend/src/main/java/com/empire/Character.java
@@ -31,12 +31,9 @@ class Character {
 		return Math.sqrt(xp + 1);
 	}
 
-	public double calcArmyLeadMod() {
-		return calcLevel(experience.general) * Constants.perLevelLeaderMod;
-	}
-
-	public double calcNavyLeadMod() {
-		return calcLevel(experience.admiral) * Constants.perLevelLeaderMod;
+	public double calcLeadMod(Army.Type type) {
+		if (type == Army.Type.ARMY) return calcLevel(experience.general) * Constants.perLevelLeaderMod;
+		else return calcLevel(experience.admiral) * Constants.perLevelLeaderMod;
 	}
 
 	public double calcGovernRecruitMod() {

--- a/backend/src/main/java/com/empire/Character.java
+++ b/backend/src/main/java/com/empire/Character.java
@@ -7,6 +7,13 @@ import java.util.HashMap;
 import java.util.Collections;
 
 class Character {
+	static class Experience {
+		double general;
+		double admiral;
+		double spy;
+		double governor;
+	}
+
 	String name = "";
 	String kingdom = "";
 	String captor = "";
@@ -15,20 +22,35 @@ class Character {
 	boolean hidden = false;
 	List<Preparation> preparation = new ArrayList<>();
 	private List<String> tags = new ArrayList<>();
-	Map<String, Double> experience = new HashMap<>();
+	private Experience experience = new Experience();
 	List<String> values = new ArrayList<>();
 	int leadingArmy = -1;
 	String orderhint = "";
 
-	// TODO: This function should technically be considered part of the game rules config IMHO
-	public int calcLevel(String dimension) {
-		return (int) Math.sqrt(experience.getOrDefault(dimension, 0.0) + 1);
+	private double calcLevel(double xp) {
+		return Math.sqrt(xp + 1);
+	}
+
+	public double calcArmyLeadMod() {
+		return calcLevel(experience.general) * Constants.perLevelLeaderMod;
+	}
+
+	public double calcNavyLeadMod() {
+		return calcLevel(experience.admiral) * Constants.perLevelLeaderMod;
+	}
+
+	public double calcGovernRecruitMod() {
+		return calcLevel(experience.governor) * Constants.perLevelGovernRecruitMod + Constants.baseGovernRecruitMod;
+	}
+
+	public double calcGovernTaxMod() {
+		return calcLevel(experience.governor) * Constants.perLevelGovernTaxMod + Constants.baseGovernTaxMod;
 	}
 
 	public double calcPlotPower(World w, boolean boosted, int inspires) {
 		double power = Constants.basePlotStrength;
 
-		power += calcLevel(Constants.charDimSpy) * Constants.perSpyLevelPlotMod;
+		power += calcLevel(experience.spy) * Constants.perSpyLevelPlotMod;
 
 		if (boosted) power += Constants.guardAgainstPlotMod;
 		if (Ideology.LYSKR == NationData.getStateReligion(kingdom, w)) power += Constants.lyskrPlotMod;
@@ -39,16 +61,27 @@ class Character {
 		return power;
 	}
 
-	public void addExperience(String dimension, World w) {
-		List<String> dims = Constants.charDimAll.equals(dimension) ? Constants.charDims : Collections.singletonList(dimension);
-		double expBase = Constants.charDimAll.equals(dimension) ? Constants.allDimExpAdd : Constants.oneDimExpAdd;
-		double expMult = w.getNation(kingdom).hasTag(NationData.Tag.HEROIC) ? Constants.heroicExpMultiplier : 1.0;
-
-		dims.forEach(d -> experience.put(d, experience.get(d) + expBase * expMult));
+	public void addExperienceAll() {
+		experience.general += Constants.allDimExpAdd;
+		experience.admiral += Constants.allDimExpAdd;
+		experience.spy += Constants.allDimExpAdd;
+		experience.governor += Constants.allDimExpAdd;
 	}
 
-	public double getExperience(String dimension){
-		return experience.get(dimension);
+	public void addExperienceGeneral() {
+		experience.general += Constants.oneDimExpAdd;
+	}
+
+	public void addExperienceAdmiral() {
+		experience.admiral += Constants.oneDimExpAdd;
+	}
+
+	public void addExperienceSpy() {
+		experience.spy += Constants.oneDimExpAdd;
+	}
+
+	public void addExperienceGovernor() {
+		experience.governor += Constants.oneDimExpAdd;
 	}
 
 	public boolean hasTag(String tag) {

--- a/backend/src/main/java/com/empire/Constants.java
+++ b/backend/src/main/java/com/empire/Constants.java
@@ -112,13 +112,6 @@ public class Constants {
     public static final double perInspirePlotMod = 0.05;
     public static final double capturedPlotMod = -0.5;
 
-    public static final String charDimAll = "*";
-    public static final String charDimGeneral = "general";
-    public static final String charDimAdmiral = "admiral";
-    public static final String charDimSpy = "spy";
-    public static final String charDimGovernor = "governor";
-    public static final List<String> charDims = Arrays.asList(charDimGeneral, charDimAdmiral, charDimSpy, charDimGovernor);
-
     public static final double oneDimExpAdd = 1.0;
     public static final double allDimExpAdd = 0.25;
     public static final double perLevelLeaderMod = 0.2;

--- a/backend/src/main/java/com/empire/Nation.java
+++ b/backend/src/main/java/com/empire/Nation.java
@@ -59,6 +59,10 @@ class Nation {
 			return e;
 		}
 
+		public boolean hasTag(NationData.Tag tag) {
+			return trait1 == tag || trait2 == tag;
+		}
+
 		@Override
 		public String toString() {
 			return getGson().toJson(this);

--- a/backend/src/main/java/com/empire/NationData.java
+++ b/backend/src/main/java/com/empire/NationData.java
@@ -9,8 +9,6 @@ import java.security.SecureRandom;
 
 class NationData {
 	enum Tag {	
-		@SerializedName("Bloodthirsty") BLOODTHIRSTY,
-		@SerializedName("Coast-Dwelling") COAST_DWELLING,
 		@SerializedName("Defensive") DEFENSIVE,
 		@SerializedName("Disciplined") DISCIPLINED,
 		@SerializedName("Evangelical") EVANGELICAL,

--- a/backend/src/main/java/com/empire/Region.java
+++ b/backend/src/main/java/com/empire/Region.java
@@ -87,7 +87,6 @@ class Region {
 		if (noble != null && noble.hasTag(Constants.nobleTyrannicalTag)) mods += Constants.nobleTyrannicalMod;
 
 		NationData wKingdom = w.getNation(kingdom);
-		if (wKingdom.hasTag(NationData.Tag.COAST_DWELLING) && isCoastal(w)) mods += Constants.coastDwellingRecruitMod;
 		if (wKingdom.hasTag(NationData.Tag.PATRIOTIC)) mods += Constants.patrioticMod;
 		if (wKingdom.hasTag(NationData.Tag.WARLIKE) && wKingdom.coreRegions.contains(w.regions.indexOf(this))) {
 			int conquests = 0;
@@ -140,7 +139,6 @@ class Region {
 		if (noble != null && noble.hasTag(Constants.nobleHoardingTag)) mods += Constants.nobleHoardingMod;
 
 		NationData wKingdom = w.getNation(kingdom);
-		if (wKingdom.hasTag(NationData.Tag.COAST_DWELLING) && isCoastal(w)) mods += Constants.coastDwellingTaxMod;
 		if (wKingdom.hasTag(NationData.Tag.MERCANTILE)) mods += Constants.mercantileTaxMod;
 		if (wKingdom.hasTag(NationData.Tag.WARLIKE) && wKingdom.coreRegions.contains(w.regions.indexOf(this))) {
 			int conquests = 0;

--- a/backend/src/main/java/com/empire/Region.java
+++ b/backend/src/main/java/com/empire/Region.java
@@ -23,7 +23,6 @@ class Region {
 	String name;
 	Type type;
 	Culture culture;
-	String climate;
 	double population;
 	Ideology religion;
 	double unrestPopular;
@@ -79,7 +78,7 @@ class Region {
 
 		if (governors != null) {
 			for (Character c : governors) {
-				mods += c.calcLevel(Constants.charDimGovernor) * Constants.perLevelGovernRecruitMod + Constants.baseGovernRecruitMod;
+				mods += c.calcGovernRecruitMod();
 			}
 		}
 
@@ -133,7 +132,7 @@ class Region {
 
 		if (governors != null) {
 			for (Character c : governors) {
-				mods += c.calcLevel(Constants.charDimGovernor) * Constants.perLevelGovernTaxMod + Constants.baseGovernTaxMod;
+				mods += c.calcGovernTaxMod();
 			}
 		}
 

--- a/backend/src/main/java/com/empire/World.java
+++ b/backend/src/main/java/com/empire/World.java
@@ -880,8 +880,7 @@ class World implements GoodwillProvider {
 					for (Army aa : armies) if (aa.id == targetId) target = aa;
 					if (target == null) continue; // ???
 					if (!target.kingdom.equals(c.kingdom) || c.location != target.location) continue;
-					Function<Character, Double> d = target.isArmy() ? cl -> cl.calcArmyLeadMod() : cl -> cl.calcNavyLeadMod();
-					if (leaders.get(target) == null || d.apply(leaders.get(target)) < d.apply(c)) {
+					if (leaders.get(target) == null || leaders.get(target).calcLeadMod(target.type) < c.calcLeadMod(target.type)) {
 						Character prev = leaders.put(target, c);
 						if (prev != null) prev.orderhint = "";
 					}
@@ -924,8 +923,7 @@ class World implements GoodwillProvider {
 
 						if (leaders.get(src) != null) {
 							leaders.get(src).orderhint = "";
-							Function<Character, Double> d = target.isArmy() ? cl -> cl.calcArmyLeadMod() : cl -> cl.calcNavyLeadMod();
-							if (leaders.get(target) == null || d.apply(leaders.get(target)) < d.apply(leaders.get(src))) leaders.put(target, leaders.get(src));
+							if (leaders.get(target) == null || leaders.get(target).calcLeadMod(target.type) < leaders.get(src).calcLeadMod(target.type)) leaders.put(target, leaders.get(src));
 						}
 					}
 				}

--- a/backend/src/main/java/com/empire/World.java
+++ b/backend/src/main/java/com/empire/World.java
@@ -1060,26 +1060,6 @@ class World implements GoodwillProvider {
 					armies.remove(army);
 				} else if (action.startsWith("Conquer")) {
 					army.conquer(World.this, action, conqueredRegions, tributes, leaders, inspires, lastStands);
-				} else if (action.startsWith("Slay Civilians")) {
-					if (!army.isArmy()) continue;
-					// Must be strongest in region (not counting other armies of the same ruler). Target region must allow refugees.
-					boolean stopped = false;
-					for (Army a : armies) {
-						if (a.isArmy() && a.location == army.location && !a.kingdom.equals(army.kingdom) && a.calcStrength(World.this, leaders.get(a), inspires, lastStands.contains(army.kingdom)) > army.calcStrength(World.this, leaders.get(army), inspires, lastStands.contains(army.kingdom))) {
-							stopped = true;
-							notifications.add(new Notification(army.kingdom, "Forced Relocation Failed", "Army " + army.id + " was prevented from forcibly relocating the population of " + region.name + " by other armies present in the region."));
-							break;
-						}
-					}
-					if (stopped) continue;
-					double slain = Math.min(region.population - 1, army.size * 10);
-					if (army.hasTag(Army.Tag.UNDEAD)) army.size += slain / 10;
-					region.unrestPopular = Math.min(1, region.unrestPopular + 3 * slain / region.population);
-					getNation(army.kingdom).goodwill -= 200;
-					addPopulation(region, -slain);
-					double refugees = Math.min(region.population - 1, army.size * 10);
-					if (refugees > 0) sendRefugees(region, null, refugees, true, null, false);
-					for (Region r : regions) if (r.getKingdom() != null && r.getKingdom().equals(army.kingdom) && r.noble != null) r.noble.unrest = Math.min(1, r.noble.unrest + .2);
 				} else if (action.startsWith("Oust ")) {
 					if (!army.isArmy()) continue;
 					if (region.noble == null) continue;
@@ -1285,11 +1265,6 @@ class World implements GoodwillProvider {
 						c.name + " attempted a daring escape at the last moment, but was unable to get free."
 					};
 					notification += flavor[(int)(Math.random() * flavor.length)];
-					if (getNation(c.captor).hasTag(NationData.Tag.BLOODTHIRSTY) && region.getKingdom().equals(c.captor)) {
-						getNation(c.captor).gold += 300;
-						incomeSources.getOrDefault(c.captor, new Budget()).incomeExecution += 300;
-						notification += " The inhabitants of " + c.captor + " celebrated the event with offerings to their ruler.";
-					}
 					notifyAllPlayers("Execution of " + c.name, notification);
 					removeCharacters.add(c);
 					if (c.hasTag("Ruler")) {

--- a/backend/src/main/java/com/empire/World.java
+++ b/backend/src/main/java/com/empire/World.java
@@ -134,14 +134,14 @@ class World implements GoodwillProvider {
 			totalSharesNavy += 1;
 			totalSharesFood += 1;
 			totalSharesPopulation += 1;
-			if ("Mercantile".equals(setup.trait1) || "Mercantile".equals(setup.trait2)) totalSharesGold += 0.5;
-			if ("Patriotic".equals(setup.trait1) || "Patriotic".equals(setup.trait2)) totalSharesArmy += 0.15;
-			if ("Rebellious".equals(setup.trait1) || "Rebellious".equals(setup.trait2)) totalSharesArmy += 0.5;
-			if ("Rebellious".equals(setup.trait1) || "Rebellious".equals(setup.trait2)) totalSharesGold += 5;
-			if ("Ruined".equals(setup.trait1) || "Ruined".equals(setup.trait2)) totalSharesPopulation -= 0.5;
-			if ("Ruined".equals(setup.trait1) || "Ruined".equals(setup.trait2)) totalSharesGold += 2;
-			if ("Seafaring".equals(setup.trait1) || "Seafaring".equals(setup.trait2)) totalSharesNavy += 0.15;
-			if ("War-like".equals(setup.trait1) || "War-like".equals(setup.trait2)) totalSharesArmy += 0.15;
+			if (setup.hasTag(NationData.Tag.MERCANTILE)) totalSharesGold += 0.5;
+			if (setup.hasTag(NationData.Tag.PATRIOTIC)) totalSharesArmy += 0.15;
+			if (setup.hasTag(NationData.Tag.REBELLIOUS)) totalSharesArmy += 0.5;
+			if (setup.hasTag(NationData.Tag.REBELLIOUS)) totalSharesGold += 5;
+			if (setup.hasTag(NationData.Tag.RUINED)) totalSharesPopulation -= 0.5;
+			if (setup.hasTag(NationData.Tag.RUINED)) totalSharesGold += 2;
+			if (setup.hasTag(NationData.Tag.SEAFARING)) totalSharesNavy += 0.15;
+			if (setup.hasTag(NationData.Tag.WARLIKE)) totalSharesArmy += 0.15;
 			if ("food".equals(setup.bonus)) totalSharesFood += 0.5;
 			else if ("armies".equals(setup.bonus)) totalSharesArmy += 0.5;
 			else if ("navies".equals(setup.bonus)) totalSharesNavy += 0.5;
@@ -156,7 +156,7 @@ class World implements GoodwillProvider {
 			nation.colorBg = con.colorBg;
 			nation.culture = con.culture;
 			nation.coreRegions = Ints.asList(con.coreRegions);
-			nation.goodwill = ("Holy".equals(setup.trait1) || "Holy".equals(setup.trait2)) ? 15 : setup.dominantIdeology.religion == Religion.IRUHAN ? 5 : -55;
+			nation.goodwill = setup.hasTag(NationData.Tag.HOLY) ? 15 : setup.dominantIdeology.religion == Religion.IRUHAN ? 5 : -55;
 			nation.gothi = new HashMap<String, Boolean>();
 			nation.gothi.put("Alyrja", false);
 			nation.gothi.put("Lyskr", false);
@@ -178,10 +178,10 @@ class World implements GoodwillProvider {
 			double sharesGold = 1;
 			double sharesFood = 1;
 			double sharesPopulation = 1;
-			if ("Mercantile".equals(setup.trait1) || "Mercantile".equals(setup.trait2)) sharesGold += 0.5;
-			if ("Rebellious".equals(setup.trait1) || "Rebellious".equals(setup.trait2)) sharesGold += 5;
-			if ("Ruined".equals(setup.trait1) || "Ruined".equals(setup.trait2)) sharesPopulation -= 0.5;
-			if ("Ruined".equals(setup.trait1) || "Ruined".equals(setup.trait2)) sharesGold += 2;
+			if (setup.hasTag(NationData.Tag.MERCANTILE)) sharesGold += 0.5;
+			if (setup.hasTag(NationData.Tag.REBELLIOUS)) sharesGold += 5;
+			if (setup.hasTag(NationData.Tag.RUINED)) sharesPopulation -= 0.5;
+			if (setup.hasTag(NationData.Tag.RUINED)) sharesGold += 2;
 			if ("food".equals(setup.bonus)) sharesFood += 0.5;
 			else if ("gold".equals(setup.bonus)) sharesGold += 0.5;
 			double population = totalPopulation * sharesPopulation / totalSharesPopulation;
@@ -238,7 +238,7 @@ class World implements GoodwillProvider {
 		for (String kingdom : nationSetup.keySet()) {
 			Nation.NationGson setup = nationSetup.get(kingdom);
 			Culture culture = WorldConstantData.kingdoms.get(kingdom).culture;
-			if ("Republican".equals(setup.trait1) || "Republican".equals(setup.trait2)) continue;
+			if (setup.hasTag(NationData.Tag.REPUBLICAN)) continue;
 			// 10 nobles.
 			ArrayList<Noble> nobles = new ArrayList<>();
 			for (String trait : new String[]{ "Inspiring", "Frugal", "Soothing", "Meticulous", "Loyal", "Policing", "Generous", "Pious", "Rationing", "Patronizing"}) {
@@ -312,10 +312,10 @@ class World implements GoodwillProvider {
 			Nation.NationGson setup = nationSetup.get(kingdom);
 			double sharesNavy = 1;
 			double sharesArmy = 1;
-			if ("Patriotic".equals(setup.trait1) || "Patriotic".equals(setup.trait2)) sharesArmy += 0.15;
-			if ("Rebellious".equals(setup.trait1) || "Rebellious".equals(setup.trait2)) sharesArmy += 0.5;
-			if ("Seafaring".equals(setup.trait1) || "Seafaring".equals(setup.trait2)) sharesNavy += 0.15;
-			if ("War-like".equals(setup.trait1) || "War-like".equals(setup.trait2)) sharesArmy += 0.15;
+			if (setup.hasTag(NationData.Tag.PATRIOTIC)) sharesArmy += 0.15;
+			if (setup.hasTag(NationData.Tag.REBELLIOUS)) sharesArmy += 0.5;
+			if (setup.hasTag(NationData.Tag.SEAFARING)) sharesNavy += 0.15;
+			if (setup.hasTag(NationData.Tag.WARLIKE)) sharesArmy += 0.15;
 			if ("armies".equals(setup.bonus)) sharesArmy += 0.5;
 			else if ("navies".equals(setup.bonus)) sharesNavy += 0.5;
 			double armies = totalArmy * sharesArmy / totalSharesArmy;
@@ -391,8 +391,8 @@ class World implements GoodwillProvider {
 				numCharacters++;
 				cardinal = true;
 			}
-			if ("Heroic".equals(setup.trait1) || "Heroic".equals(setup.trait2)) numCharacters += 2;
-			if ("Republican".equals(setup.trait1) || "Republican".equals(setup.trait2)) numCharacters += 1;
+			if (setup.hasTag(NationData.Tag.HEROIC)) numCharacters += 2;
+			if (setup.hasTag(NationData.Tag.REPUBLICAN)) numCharacters += 1;
 			for (int i = 0; i < numCharacters; i++) {
 				Character c = new Character();
 				c.name = WorldConstantData.getRandomName(WorldConstantData.kingdoms.get(kingdom).culture, Math.random() < 0.5 ? WorldConstantData.Gender.MAN : WorldConstantData.Gender.WOMAN);

--- a/backend/src/test/java/com/empire/ArmyTest.java
+++ b/backend/src/test/java/com/empire/ArmyTest.java
@@ -202,30 +202,24 @@ public class ArmyTest {
 
 	@Test
 	public void calcStrengthCaptured() {
-		Character leader = new Character();
-		leader.addExperienceGeneral();
-		leader.addExperienceGeneral();
-		leader.addExperienceGeneral();
+		Character leader = Mocks.character();
+		when(leader.calcLeadMod(Army.Type.ARMY)).thenReturn(.4);
 		leader.captor = "DONTCARE";
 		assertEquals(1.0, a.calcStrength(w, leader, 0, false), DELTA);
 	}
 
 	@Test
 	public void calcStrengthGeneral() {
-		Character c = new Character();
-		c.addExperienceGeneral();
-		c.addExperienceGeneral();
-		c.addExperienceGeneral();
+		Character c = Mocks.character();
+		when(c.calcLeadMod(Army.Type.ARMY)).thenReturn(.4);
 		assertEquals(1.4, a.calcStrength(w, c, 0, false), DELTA);
 	}
 
 	@Test
 	public void calcStrengthAdmiral() {
 		a.type = Army.Type.NAVY;
-		Character c = new Character();
-		c.addExperienceAdmiral();
-		c.addExperienceAdmiral();
-		c.addExperienceAdmiral();
+		Character c = Mocks.character();
+		when(c.calcLeadMod(Army.Type.NAVY)).thenReturn(.4);
 		assertEquals(140.0, a.calcStrength(w, c, 0, false), DELTA);
 	}
 

--- a/backend/src/test/java/com/empire/ArmyTest.java
+++ b/backend/src/test/java/com/empire/ArmyTest.java
@@ -202,23 +202,30 @@ public class ArmyTest {
 
 	@Test
 	public void calcStrengthCaptured() {
-		Character leader = Mocks.character(3.0);
+		Character leader = new Character();
+		leader.addExperienceGeneral();
+		leader.addExperienceGeneral();
+		leader.addExperienceGeneral();
 		leader.captor = "DONTCARE";
 		assertEquals(1.0, a.calcStrength(w, leader, 0, false), DELTA);
 	}
 
 	@Test
 	public void calcStrengthGeneral() {
-		Character c = Mocks.character(3.0);
-		when(c.calcLevel(Constants.charDimGeneral)).thenReturn(2);
+		Character c = new Character();
+		c.addExperienceGeneral();
+		c.addExperienceGeneral();
+		c.addExperienceGeneral();
 		assertEquals(1.4, a.calcStrength(w, c, 0, false), DELTA);
 	}
 
 	@Test
 	public void calcStrengthAdmiral() {
 		a.type = Army.Type.NAVY;
-		Character c = Mocks.character(3.0);
-		when(c.calcLevel(Constants.charDimAdmiral)).thenReturn(2);
+		Character c = new Character();
+		c.addExperienceAdmiral();
+		c.addExperienceAdmiral();
+		c.addExperienceAdmiral();
 		assertEquals(140.0, a.calcStrength(w, c, 0, false), DELTA);
 	}
 

--- a/backend/src/test/java/com/empire/CharacterTest.java
+++ b/backend/src/test/java/com/empire/CharacterTest.java
@@ -45,9 +45,9 @@ public class CharacterTest {
 
     @Test
     public void calcPlotPowerSpyLevel() {
-				c.addExperienceSpy();
-				c.addExperienceSpy();
-				c.addExperienceSpy();
+        c.addExperienceSpy();
+        c.addExperienceSpy();
+        c.addExperienceSpy();
         assertEquals(1.6, c.calcPlotPower(w, false, 0), DELTA);
     }
 

--- a/backend/src/test/java/com/empire/CharacterTest.java
+++ b/backend/src/test/java/com/empire/CharacterTest.java
@@ -22,7 +22,6 @@ public class CharacterTest {
     public void createCharacter() {
         c = new Character();
         c.kingdom = k1;
-        setExperience(0.0);
 
         w = mockWorld();
     }
@@ -39,107 +38,6 @@ public class CharacterTest {
         return world;
     }
 
-    private void setExperience(double exp) {
-        setExperience(exp, exp, exp, exp);
-    }
-
-    private void setExperience(double general, double admiral, double governor, double spy) {
-        c.experience.put(Constants.charDimGeneral, general);
-        c.experience.put(Constants.charDimAdmiral, admiral);
-        c.experience.put(Constants.charDimGovernor, governor);
-        c.experience.put(Constants.charDimSpy, spy);
-    }
-
-    private void addHeroicTag() {
-        when(n1.hasTag(NationData.Tag.HEROIC)).thenReturn(true);
-    }
-
-    private void assertDimsExpEqual(double general, double admiral, double governor, double spy) {
-        assertEquals(general, c.getExperience(Constants.charDimGeneral), DELTA);
-        assertEquals(admiral, c.getExperience(Constants.charDimAdmiral), DELTA);
-        assertEquals(governor, c.getExperience(Constants.charDimGovernor), DELTA);
-        assertEquals(spy, c.getExperience(Constants.charDimSpy), DELTA);
-    }
-
-    @Test
-    public void calcLevelAll() {
-        List<Double> expLevel = Arrays.asList(1.0, 4.0, 9.0, 16.0, 25.0);
-
-        for(int level = 1; level <= 5; level++) {
-            setExperience(expLevel.get(level-1));
-            assertEquals(level, c.calcLevel(Constants.charDimGeneral));
-            assertEquals(level, c.calcLevel(Constants.charDimAdmiral));
-            assertEquals(level, c.calcLevel(Constants.charDimGovernor));
-            assertEquals(level, c.calcLevel(Constants.charDimSpy));
-        }
-    }
-
-    @Test
-    public void addExperienceGeneralRegular() {
-        c.addExperience(Constants.charDimGeneral, w);
-        assertDimsExpEqual(1.0, 0.0, 0.0, 0.0);
-    }
-
-    @Test
-    public void addExperienceAdmirallRegular() {
-        c.addExperience(Constants.charDimAdmiral, w);
-        assertDimsExpEqual(0.0, 1.0, 0.0, 0.0);
-    }
-
-    @Test
-    public void addExperienceGovernorRegular() {
-        c.addExperience(Constants.charDimGovernor, w);
-        assertDimsExpEqual(0.0, 0.0, 1.0, 0.0);
-    }
-
-    @Test
-    public void addExperienceSpyRegular() {
-        c.addExperience(Constants.charDimSpy, w);
-        assertDimsExpEqual(0.0, 0.0, 0.0, 1.0);
-
-    }
-
-    @Test
-    public void addExperienceAllRegular() {
-        c.addExperience(Constants.charDimAll, w);
-        assertDimsExpEqual(0.25, 0.25, 0.25, 0.25);
-    }
-
-    @Test
-    public void addExperienceGeneralHeroic() {
-        addHeroicTag();
-        c.addExperience(Constants.charDimGeneral, w);
-        assertDimsExpEqual(2.0, 0.0, 0.0, 0.0);
-    }
-
-    @Test
-    public void addExperienceAdmiralHeroic() {
-        addHeroicTag();
-        c.addExperience(Constants.charDimAdmiral, w);
-        assertDimsExpEqual(0.0, 2.0, 0.0, 0.0);
-    }
-
-    @Test
-    public void addExperienceGovernorHeroic() {
-        addHeroicTag();
-        c.addExperience(Constants.charDimGovernor, w);
-        assertDimsExpEqual(0.0, 0.0, 2.0, 0.0);
-    }
-
-    @Test
-    public void addExperienceSpyHeroic() {
-        addHeroicTag();
-        c.addExperience(Constants.charDimSpy, w);
-        assertDimsExpEqual(0.0, 0.0, 0.0, 2.0);
-    }
-
-    @Test
-    public void addExperienceAllHeroic() {
-        addHeroicTag();
-        c.addExperience(Constants.charDimAll, w);
-        assertDimsExpEqual(0.5, 0.5, 0.5, 0.5);
-    }
-
     @Test
     public void calcPlotPowerBasic() {
         assertEquals(1.3, c.calcPlotPower(w, false, 0), DELTA);
@@ -147,7 +45,9 @@ public class CharacterTest {
 
     @Test
     public void calcPlotPowerSpyLevel() {
-        setExperience(4.0);
+				c.addExperienceSpy();
+				c.addExperienceSpy();
+				c.addExperienceSpy();
         assertEquals(1.6, c.calcPlotPower(w, false, 0), DELTA);
     }
 

--- a/backend/src/test/java/com/empire/Mocks.java
+++ b/backend/src/test/java/com/empire/Mocks.java
@@ -22,18 +22,4 @@ class Mocks {
         when(n.hasTag(nobleTag)).thenReturn(true);
         return n;
     }
-
-    public static Character character(double general, double admiral, double governor, double spy) {
-        Character c = mock(Character.class);
-        c.captor = Constants.noCaptor;
-        when(c.getExperience(Constants.charDimGeneral)).thenReturn(general);
-        when(c.getExperience(Constants.charDimAdmiral)).thenReturn(admiral);
-        when(c.getExperience(Constants.charDimGovernor)).thenReturn(governor);
-        when(c.getExperience(Constants.charDimSpy)).thenReturn(spy);
-        return c;
-    }
-
-    public static Character character(double xp) {
-        return Mocks.character(xp, xp, xp, xp);
-    }
 }

--- a/backend/src/test/java/com/empire/Mocks.java
+++ b/backend/src/test/java/com/empire/Mocks.java
@@ -5,21 +5,27 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class Mocks {
-    public static Region region(String kingdom, Region.Type type, double population, Ideology religion) {
-        Region r = mock(Region.class);
-        when(r.getKingdom()).thenReturn(kingdom);
-        r.type = type;
-        r.population = population;
-        r.religion = religion;
-        r.constructions = new ArrayList<>();
-        return r;
-    }
+	public static Region region(String kingdom, Region.Type type, double population, Ideology religion) {
+		Region r = mock(Region.class);
+		when(r.getKingdom()).thenReturn(kingdom);
+		r.type = type;
+		r.population = population;
+		r.religion = religion;
+		r.constructions = new ArrayList<>();
+		return r;
+	}
 
-    public static Noble noble(String nobleTag, double unrest) {
-        Noble n = mock(Noble.class);
-        n.unrest = unrest;
-        n.name = "DONTCARE";
-        when(n.hasTag(nobleTag)).thenReturn(true);
-        return n;
-    }
+	public static Noble noble(String nobleTag, double unrest) {
+		Noble n = mock(Noble.class);
+		n.unrest = unrest;
+		n.name = "DONTCARE";
+		when(n.hasTag(nobleTag)).thenReturn(true);
+		return n;
+	}
+
+	public static Character character() {
+		Character c = mock(Character.class);
+		c.captor = Constants.noCaptor;
+		return c;
+	}
 }

--- a/frontend/character-report.js
+++ b/frontend/character-report.js
@@ -96,18 +96,9 @@ class CharacterReport extends HTMLElement {
 		shadow.appendChild(content);
 		// Add skills.
 		for (let skill of ["admiral", "general", "governor", "spy"]) {
-			let l = c.calcLevel(skill);
-			let s = "";
-			for (let i = 0; i < l; i++) {
-				s += "★";
-			}
-			let x = c.experience[skill];
-			let rem = x >= 24 ? -1 : x >= 15 ? 24 - x : x >= 8 ? 15 - x : x >= 3 ? 8 - x : 3 - x;
-			if (rem == -1) rem = "Max level.";
-			else rem = rem + " experience to next level.";
 			let t = document.createElement("tooltip-element");
-			t.innerHTML = s;
-			t.setAttribute("tooltip", getEffect(l, skill) + " " + rem);
+			t.innerHTML = Math.floor(c.calcLevel(skill) * 100) / 100;
+			t.setAttribute("tooltip", getEffect(l, skill));
 			shadow.getElementById("skill_" + skill).appendChild(t);
 		}
 		// If values, show them; else hide them.

--- a/frontend/church-report.js
+++ b/frontend/church-report.js
@@ -52,7 +52,6 @@ class ChurchReport extends HTMLElement {
 					<div>Construct Temple (non-Iruhan)</div><div>-20</div>
 					<div>Battle in Sancta Civitate</div><div>-40</div>
 					<div>Execute a Captive</div><div>-40</div>
-					<div>Slay Civilians</div><div>-200</div>
 				</div>
 			</div>
 		`;

--- a/frontend/gamelib.js
+++ b/frontend/gamelib.js
@@ -156,7 +156,6 @@ class Region {
 		this.name = dataEntry.name;
 		this.type = dataEntry.type;
 		this.path = constEntry.path;
-		this.climate = dataEntry.climate;
 		this.culture = dataEntry.culture;
 		this.population = dataEntry.population;
 		this.kingdom = dataEntry.kingdom;

--- a/frontend/gamelib.js
+++ b/frontend/gamelib.js
@@ -188,7 +188,6 @@ class Region {
 			for (let r of this.getNeighbors()) if (r.type == "land" && (r.culture != this.culture || r.religion != this.religion)) getTapestryBonus = true;
 			if (getTapestryBonus) mods.push({"v": .5, "unit": "%", "why": "Tapestry of People ideology"});
 		}
-		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Coast-Dwelling") && this.isCoastal()) mods.push({"v": .12, "unit": "%", "why": "Coast-Dwelling rulers"});
 		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Patriotic")) mods.push({"v": .15, "unit": "%", "why": "Patriotic rulers"});
 		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "War-like") && contains(getNation(this.kingdom).core_regions, this.id)) {
 			let conquests = 0;
@@ -226,7 +225,6 @@ class Region {
 		let mods = [];
 		if (contains(this.noble.tags, "Frugal")) mods.push({"v": .5, "unit": "%", "why": "Noble"});
 		if (contains(this.noble.tags, "Hoarding")) mods.push({"v": -.35, "unit": "%", "why": "Noble"});
-		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Coast-Dwelling") && this.isCoastal()) mods.push({"v": .12, "unit": "%", "why": "Coast-Dwelling rulers"});
 		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Mercantile")) mods.push({"v": .15, "unit": "%", "why": "Mercantile rulers"});
 		let neighborKuun = false;
 		for (let r of this.getNeighbors()) if (r.kingdom != this.kingdom && r.kingdom != undefined && r.kingdom != "Unruled" && getNation(r.kingdom).calcStateReligion() == "Tavian (River of Kuun)") neighborKuun = true;
@@ -674,11 +672,7 @@ class Character {
 	}
 
 	calcLevel(dimension) {
-		if (this.experience[dimension] >= 24) return 5;
-		if (this.experience[dimension] >= 15) return 4;
-		if (this.experience[dimension] >= 8) return 3;
-		if (this.experience[dimension] >= 3) return 2;
-		return 1;
+		return Math.sqrt(this.experience[dimension] + 1);
 	}
 
 	calcPlotPower() {

--- a/frontend/gamelib.js
+++ b/frontend/gamelib.js
@@ -170,12 +170,14 @@ class Region {
 	}
 
 	calcRecruitment(extraMod=0) {
-		let base = new Calc("*", [
+		let baseAmount = [
 			{"v": this.population, "unit": " citizens", "why": "Regional Population"},
-			{"v": 1 / 2000.0, "unit": " recruits / citizen", "why": "Recruitment Rate"}]);
-		let mods = [];
+			{"v": 1 / 2000.0, "unit": " recruits / citizen", "why": "Recruitment Rate"}];
 		let unrest = this.calcUnrest().v;
-		if (unrest > .25) mods.push({"v": .25 - unrest, "unit": "%", "why": "Unrest"});
+		if (unrest > .25) baseAmount.push({"v": 1.25 - unrest, "unit": "%", "why": "Unrest"});
+		let base = new Calc("*", baseAmount);
+
+		let mods = [];
 		if (contains(this.noble.tags, "Inspiring")) mods.push({"v": .5, "unit": "%", "why": "Noble"});
 		if (contains(this.noble.tags, "Untrusting")) mods.push({"v": -.35, "unit": "%", "why": "Noble"});
 		if (contains(this.noble.tags, "Tyrannical")) mods.push({"v": -.5, "unit": "%", "why": "Noble"});
@@ -214,12 +216,14 @@ class Region {
 	}
 
 	calcTaxation(extraMod=0) {
-		let base = new Calc("*", [
+		let baseAmount = [
 			{"v": this.population, "unit": " citizens", "why": "Regional Population"},
-			{"v": 1 / 10000.0, "unit": " gold / citizen", "why": "Base Taxation Rate"}]);
-		let mods = [];
+			{"v": 1 / 10000.0, "unit": " gold / citizen", "why": "Base Taxation Rate"}];
 		let unrest = this.calcUnrest().v;
-		if (unrest > .25) mods.push({"v": .25 - unrest, "unit": "%", "why": "Unrest"});
+		if (unrest > .25) baseAmount.push({"v": 1.25 - unrest, "unit": "%", "why": "Unrest"});
+		let base = new Calc("*", baseAmount);
+
+		let mods = [];
 		if (contains(this.noble.tags, "Frugal")) mods.push({"v": .5, "unit": "%", "why": "Noble"});
 		if (contains(this.noble.tags, "Hoarding")) mods.push({"v": -.35, "unit": "%", "why": "Noble"});
 		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Coast-Dwelling") && this.isCoastal()) mods.push({"v": .12, "unit": "%", "why": "Coast-Dwelling rulers"});

--- a/frontend/map1.html
+++ b/frontend/map1.html
@@ -263,9 +263,6 @@
 					.v_culture .hansa { fill: #fc4; }
 					.v_culture .tyrgaetan { fill: #aaa; }
 					.v_culture .tavian { fill: #a4c; }
-					.v_climate .green { fill: #afa;  }
-					.v_climate .seasonal { fill: #ff8; }
-					.v_climate .treacherous { fill: #f00; }
 					.v_religion .Iruhan_Sword_of_Truth { fill: #f00; }
 					.v_religion .Iruhan_Vessel_of_Faith { fill: #f80; }
 					.v_religion .Iruhan_Chalice_of_Compassion { fill: #f88; }
@@ -332,7 +329,6 @@
 						let cname = r.kingdom.toLowerCase();
 						cname += " " + r.culture;
 						cname += " pop" + Math.floor(r.population);
-						cname += " " + r.climate;
 						cname += " " + r.religion.replace(/[ ']/g, "_").replace("(", "").replace(")", "");
 						cname += " unrest" + Math.floor(100 * r.calcUnrest().v);
 						cname += " food" + Math.min(13 + (13 - ((g_data.date + 52 - 12) % 13)) % 13, Math.floor(r.calcFoodWeeks().v));
@@ -603,7 +599,6 @@
 				<label title="Cultural Map"      onclick="changeClass('regions', 'v_', 'culture')"   ><input type="radio" name="view"        /><svg style="width:24px;height:24px" viewBox="0 0 24 24"><path d="M20.71,4.63L19.37,3.29C19,2.9 18.35,2.9 17.96,3.29L9,12.25L11.75,15L20.71,6.04C21.1,5.65 21.1,5 20.71,4.63M7,14A3,3 0 0,0 4,17C4,18.31 2.84,19 2,19C2.92,20.22 4.5,21 6,21A4,4 0 0,0 10,17A3,3 0 0,0 7,14Z" /></svg></label>
 				<label title="Religious Map"     onclick="changeClass('regions', 'v_', 'religion')"  ><input type="radio" name="view"        /><svg style="width:24px;height:24px" viewBox="0 0 24 24"><path d="M11,2H13V4H15V6H13V9.4L22,13V15L20,14.2V22H14V17A2,2 0 0,0 12,15A2,2 0 0,0 10,17V22H4V14.2L2,15V13L11,9.4V6H9V4H11V2M6,20H8V15L7,14L6,15V20M16,20H18V15L17,14L16,15V20Z" /></svg></label>
 				<label title="Population Map"    onclick="changeClass('regions', 'v_', 'population')"><input type="radio" name="view"        /><svg style="width:24px;height:24px" viewBox="0 0 24 24"><path d="M16,13C15.71,13 15.38,13 15.03,13.05C16.19,13.89 17,15 17,16.5V19H23V16.5C23,14.17 18.33,13 16,13M8,13C5.67,13 1,14.17 1,16.5V19H15V16.5C15,14.17 10.33,13 8,13M8,11A3,3 0 0,0 11,8A3,3 0 0,0 8,5A3,3 0 0,0 5,8A3,3 0 0,0 8,11M16,11A3,3 0 0,0 19,8A3,3 0 0,0 16,5A3,3 0 0,0 13,8A3,3 0 0,0 16,11Z" /></svg></label>
-				<label title="Climate Map"       onclick="changeClass('regions', 'v_', 'climate')"   ><input type="radio" name="view"        /><svg style="width:24px;height:24px" viewBox="0 0 24 24"><path d="M20.79,13.95L18.46,14.57L16.46,13.44V10.56L18.46,9.43L20.79,10.05L21.31,8.12L19.54,7.65L20,5.88L18.07,5.36L17.45,7.69L15.45,8.82L13,7.38V5.12L14.71,3.41L13.29,2L12,3.29L10.71,2L9.29,3.41L11,5.12V7.38L8.5,8.82L6.5,7.69L5.92,5.36L4,5.88L4.47,7.65L2.7,8.12L3.22,10.05L5.55,9.43L7.55,10.56V13.45L5.55,14.58L3.22,13.96L2.7,15.89L4.47,16.36L4,18.12L5.93,18.64L6.55,16.31L8.55,15.18L11,16.62V18.88L9.29,20.59L10.71,22L12,20.71L13.29,22L14.7,20.59L13,18.88V16.62L15.5,15.17L17.5,16.3L18.12,18.63L20,18.12L19.53,16.35L21.3,15.88L20.79,13.95M9.5,10.56L12,9.11L14.5,10.56V13.44L12,14.89L9.5,13.44V10.56Z" /></svg></label>
 				<label title="Starvation Map"    onclick="changeClass('regions', 'v_', 'food')"      ><input type="radio" name="view"        /><svg style="width:24px;height:24px" viewBox="0 0 24 24"><path d="M7.33,18.33C6.5,17.17 6.5,15.83 6.5,14.5C8.17,15.5 9.83,16.5 10.67,17.67L11,18.23V15.95C9.5,15.05 8.08,14.13 7.33,13.08C6.5,11.92 6.5,10.58 6.5,9.25C8.17,10.25 9.83,11.25 10.67,12.42L11,13V10.7C9.5,9.8 8.08,8.88 7.33,7.83C6.5,6.67 6.5,5.33 6.5,4C8.17,5 9.83,6 10.67,7.17C10.77,7.31 10.86,7.46 10.94,7.62C10.77,7 10.66,6.42 10.65,5.82C10.64,4.31 11.3,2.76 11.96,1.21C12.65,2.69 13.34,4.18 13.35,5.69C13.36,6.32 13.25,6.96 13.07,7.59C13.15,7.45 13.23,7.31 13.33,7.17C14.17,6 15.83,5 17.5,4C17.5,5.33 17.5,6.67 16.67,7.83C15.92,8.88 14.5,9.8 13,10.7V13L13.33,12.42C14.17,11.25 15.83,10.25 17.5,9.25C17.5,10.58 17.5,11.92 16.67,13.08C15.92,14.13 14.5,15.05 13,15.95V18.23L13.33,17.67C14.17,16.5 15.83,15.5 17.5,14.5C17.5,15.83 17.5,17.17 16.67,18.33C15.92,19.38 14.5,20.3 13,21.2V23H11V21.2C9.5,20.3 8.08,19.38 7.33,18.33Z" /></svg></label>
 				<label title="Unrest Map"        onclick="changeClass('regions', 'v_', 'unrest')"    ><input type="radio" name="view"        /><svg style="width:24px;height:24px" viewBox="0 0 24 24"><path d="M20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12M22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12M15.5,8C16.3,8 17,8.7 17,9.5C17,10.3 16.3,11 15.5,11C14.7,11 14,10.3 14,9.5C14,8.7 14.7,8 15.5,8M10,9.5C10,10.3 9.3,11 8.5,11C7.7,11 7,10.3 7,9.5C7,8.7 7.7,8 8.5,8C9.3,8 10,8.7 10,9.5M12,14C13.75,14 15.29,14.72 16.19,15.81L14.77,17.23C14.32,16.5 13.25,16 12,16C10.75,16 9.68,16.5 9.23,17.23L7.81,15.81C8.71,14.72 10.25,14 12,14Z" /></svg></label>
 			</div>

--- a/frontend/orders-pane.js
+++ b/frontend/orders-pane.js
@@ -1175,9 +1175,6 @@ class OrdersPane extends HTMLElement {
 			if (o.value.startsWith("Travel to ")) {
 				let dest = undefined;
 				for (let r of g_data.regions) if (r.name == o.value.replace("Travel to ", "")) dest = r;
-				if (dest != undefined && (dest.type != "land" || dest.kingdom == "Unruled" || g_data.kingdoms[dest.kingdom].calcRelationship(g_data.kingdoms[a.kingdom]) != "friendly") && !contains(a.tags, "Weathered") && (dest.climate == "treacherous" || (dest.climate == "seasonal" && (g_data.date % 52 < 13 || g_data.date % 52 >= 39)))) {
-					warn = "(will suffer 25% attrition due to climate)";
-				}
 				if (a.type == "navy" && dest.type == "land" && g_data.regions[a.location].type == "land" && !g_data.tivar.deluge) {
 					warn += "(navies can only move between land regions during the Deluge)";
 				}

--- a/frontend/orders-pane.js
+++ b/frontend/orders-pane.js
@@ -947,7 +947,6 @@ class OrdersPane extends HTMLElement {
 				opts.push("Raze " + c);
 			}
 			if (r.kingdom == unit.kingdom && r.noble.name != undefined) opts.push("Oust Noble");
-			if (r.type == "land") opts.push("Slay Civilians");
 			for (let neighbor of r.getNeighbors()) opts.push("Travel to " + neighbor.name);
 			if (r.population > 1) for (let neighbor of r.getNeighbors()) if (neighbor.type == "land") opts.push("Force civilians to " + neighbor.name);
 		} else {
@@ -1185,8 +1184,6 @@ class OrdersPane extends HTMLElement {
 				let ot = undefined;
 				for (let aa of g_data.armies) if (aa.id == parseInt(o.value.replace("Merge into army ", ""))) ot = aa;
 				if (ot.tags[0] != a.tags[0] || ot.tags[1] != a.tags[1]) warn = "(67% of the army will merge, 33% will turn to piracy)";
-			} else if (o.value.startsWith("Slay")) {
-				warn = "(will anger the Church of Iruhan)";
 			} else if (o.value.startsWith("Patrol")) {
 				if (a.calcStrength().v < g_data.regions[a.location].calcMinPatrolSize().v) {
 					warn = "(army may be too small to patrol)";

--- a/frontend/region-report.js
+++ b/frontend/region-report.js
@@ -10,12 +10,6 @@ class RegionReport extends HTMLElement {
 
 		let shadow = this.attachShadow({mode: "open"});
 		
-		let climate_tooltips = {
-			"green": "Ideal climate. No special effects.",
-			"seasonal": "During winter only, this region causes 25% attrition to enemy or neutral armies or navies entering it.",
-			"treacherous": "This region causes 25% attrition to enemy or neutral armies or navies entering it."
-		};
-
 		let culture_tooltips = {
 			"eolsung": "Eolsung are hearty northerners. Soldiers recruited in this region make skilled raiders, able to conceal their presence and attack enemy supply lines.",
 			"anpilayn": "Anpilayn are cultured southerners. Soldiers recruited in this region are well-equipped and extremely formidable in battle.",
@@ -42,7 +36,7 @@ class RegionReport extends HTMLElement {
 			html = `
 				<div id="name">${r.name}</div>
 				<div id="kingdom"><report-link href="kingdom/${r.kingdom}">${r.kingdom}</report-link></div>
-				<div id="cct"><tooltip-element tooltip="${climate_tooltips[r.climate]}">${r.climate}</tooltip-element></div>
+				<div id="cct"></div>
 				<div id="content">
 					<h1><tooltip-element tooltip="A region's population determines its tax production, recruitment, maximum harvest size, and food consumption. Population grows slowly, but regions can also attract refugees from neighboring regions that have battles or starvation.">Population</tooltip-element>: <tooltip-element tooltip="${r.population}">${Math.round(r.population / 1000)}k</tooltip-element></h1>
 					<div>
@@ -87,7 +81,7 @@ class RegionReport extends HTMLElement {
 			html = `
 				<div id="name">${r.name}</div>
 				<div id="kingdom">Sea Region</div>
-				<div id="cct"><tooltip-element tooltip="${climate_tooltips[r.climate]}">${r.climate}</tooltip-element></div>
+				<div id="cct"></div>
 				<div id="content">
 					<h1>Contents</h1>
 					<div id="objects"></div>

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -336,7 +336,7 @@
 				"Defensive": "Your people are twice as effective at constructing fortifications.",
 				"Disciplined": "Your armies are more effective, and any pirates that enter your regions lose 25% of their strength.",
 				"Evangelical": "Your people will fund the spreading of your state religion.",
-				"Heroic": "Your characters learn new skills twice as quickly.",
+				"Heroic": "You control extra heroic characters.",
 				"Holy": "While your state ideology matches the dominant Iruhan ideology, the Church of Iruhan will donate about twice as much gold to you.",
 				"Imperialistic": "Nations that pay you tribute receive benefits, and you receive extra benefits from each nation paying you tribute.",
 				"Industrial": "All construction in your nation is inexpensive.",

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -331,8 +331,6 @@
 				"Tavian (River of Kuun)": "Your people broadly believe that the duty of the fortunate is to provide for the unfortunate. Any feasts you throw will trigger economic activity and other nations will generate more income for sharing borders with you.",
 			};
 			let traitConsequences = {
-				"Bloodthirsty": "Bringing captives from other kingdoms into your territory and executing them will earn you gold.",
-				"Coast-Dwelling": "Your coastal populations produce more tax and recruits.",
 				"Defensive": "Your people are twice as effective at constructing fortifications.",
 				"Disciplined": "Your armies are more effective, and any pirates that enter your regions lose 25% of their strength.",
 				"Evangelical": "Your people will fund the spreading of your state religion.",


### PR DESCRIPTION
Elimination of some r4 rules:
 • Bloodthirsty
 • Slay Civilians
 • Coast-Dwelling
 • Regional climates
Minor r5 modifications:
 • Heroic and Republican grant bonus characters.
 • Character levels can be fractional.
Bug fix:
 • FE tax/recruitment calculations were treating unrest as additively combined with other mods.