### PR TITLE
Implement r5 trait tweaks

### DIFF
--- a/backend/src/main/java/com/empire/Army.java
+++ b/backend/src/main/java/com/empire/Army.java
@@ -49,7 +49,7 @@ class Army {
 
 		if (hasTag(Tag.STEEL)) mods += Constants.steelMod;
 		if (hasTag(Tag.SEAFARING) && r.isSea()) mods += Constants.seafaringMod;
-		if (isArmy() && !Constants.pirateKingdom.equals(kingdom) && w.getNation(kingdom).hasTag(NationData.Tag.DISCIPLINED)) mods += Constants.disciplinedMod;
+		if (isArmy() && !Constants.pirateKingdom.equals(kingdom) && w.getNation(kingdom).hasTag(NationData.Tag.DISCIPLINED)) mods += Constants.disciplinedArmyStrengthMod;
 		if (isArmy() && r.isLand() && NationData.isFriendly(r.getKingdom(), kingdom, w)) mods += r.calcFortificationMod();
 		if (Ideology.SWORD_OF_TRUTH == w.getDominantIruhanIdeology()) {
 			Ideology sr = NationData.getStateReligion(kingdom, w);

--- a/backend/src/main/java/com/empire/Constants.java
+++ b/backend/src/main/java/com/empire/Constants.java
@@ -97,6 +97,7 @@ public class Constants {
 	public static final double heroicExpMultiplier = 2.0;
 
 	public static final double disciplinedMod = 0.1;
+	public static final double disciplinedPatrolStrengthMod = -.5;
 
 	public static final double coastDwellingRecruitMod = 0.12;
 	public static final double coastDwellingTaxMod = 0.12;
@@ -111,7 +112,7 @@ public class Constants {
 	public static final double mercantileTaxMod = 0.15;
 	public static final double mercantileGoldShare = 0.5;
 
-	public static final double stoicConqStrengthMod = 0.75;
+	public static final double stoicConqStrengthMod = 1.5;
 
 	// Regions
 	public static final double recruitmentPerPop = 1.0 / 2000.0;

--- a/backend/src/main/java/com/empire/Constants.java
+++ b/backend/src/main/java/com/empire/Constants.java
@@ -96,7 +96,7 @@ public class Constants {
 	public static final String nationHeroicTag = "Heroic";
 	public static final double heroicExpMultiplier = 2.0;
 
-	public static final double disciplinedMod = 0.1;
+	public static final double disciplinedArmyStrengthMod = 0.1;
 	public static final double disciplinedPatrolStrengthMod = -.5;
 
 	public static final double coastDwellingRecruitMod = 0.12;

--- a/backend/src/main/java/com/empire/NationData.java
+++ b/backend/src/main/java/com/empire/NationData.java
@@ -22,7 +22,6 @@ class NationData {
 		@SerializedName("Patriotic") PATRIOTIC,
 		@SerializedName("Rebellious") REBELLIOUS,
 		@SerializedName("Republican") REPUBLICAN,
-		@SerializedName("Ruined") RUINED,
 		@SerializedName("Seafaring") SEAFARING,
 		@SerializedName("Ship-Building") SHIP_BUILDING,
 		@SerializedName("Stoic") STOIC,

--- a/backend/src/main/java/com/empire/Region.java
+++ b/backend/src/main/java/com/empire/Region.java
@@ -334,7 +334,10 @@ class Region {
 
 	// TODO: This is a game rule/equation
 	public double calcMinPatrolStrength(World w) {
-		return 0.03 * Math.sqrt(population) * (1 + (2 * calcUnrest(w) - 0.7));
+		double mods = 1;
+		if (w.getNation(kingdom).hasTag(NationData.Tag.DISCIPLINED)) mods += Constants.disciplinedPatrolStrengthMod;
+		mods += (2 * calcUnrest(w) - 0.7);
+		return 0.03 * Math.sqrt(population) * mods;
 	}
 
 	public double calcFortificationPct() {

--- a/backend/src/main/java/com/empire/World.java
+++ b/backend/src/main/java/com/empire/World.java
@@ -138,8 +138,6 @@ class World implements GoodwillProvider {
 			if (setup.hasTag(NationData.Tag.PATRIOTIC)) totalSharesArmy += 0.15;
 			if (setup.hasTag(NationData.Tag.REBELLIOUS)) totalSharesArmy += 0.5;
 			if (setup.hasTag(NationData.Tag.REBELLIOUS)) totalSharesGold += 5;
-			if (setup.hasTag(NationData.Tag.RUINED)) totalSharesPopulation -= 0.5;
-			if (setup.hasTag(NationData.Tag.RUINED)) totalSharesGold += 2;
 			if (setup.hasTag(NationData.Tag.SEAFARING)) totalSharesNavy += 0.15;
 			if (setup.hasTag(NationData.Tag.WARLIKE)) totalSharesArmy += 0.15;
 			if ("food".equals(setup.bonus)) totalSharesFood += 0.5;
@@ -180,8 +178,6 @@ class World implements GoodwillProvider {
 			double sharesPopulation = 1;
 			if (setup.hasTag(NationData.Tag.MERCANTILE)) sharesGold += 0.5;
 			if (setup.hasTag(NationData.Tag.REBELLIOUS)) sharesGold += 5;
-			if (setup.hasTag(NationData.Tag.RUINED)) sharesPopulation -= 0.5;
-			if (setup.hasTag(NationData.Tag.RUINED)) sharesGold += 2;
 			if ("food".equals(setup.bonus)) sharesFood += 0.5;
 			else if ("gold".equals(setup.bonus)) sharesGold += 0.5;
 			double population = totalPopulation * sharesPopulation / totalSharesPopulation;
@@ -360,6 +356,13 @@ class World implements GoodwillProvider {
 				for (int i = 0; i < shipyardsPerNation; i++) {
 					regions.get((int)(Math.random() * regions.size())).constructions.add(Construction.makeShipyard(Constants.baseCostShipyard));
 				}
+			}
+		}
+		// Place defensive fortifications.
+		for (Region r : w.regions) {
+			if (nationSetup.containsKey(r.getKingdom()) && nationSetup.get(r.getKingdom()).hasTag(NationData.Tag.DEFENSIVE)) {
+				r.constructions.add(Construction.makeFortifications(Constants.baseCostFortifications));
+				r.constructions.add(Construction.makeFortifications(Constants.baseCostFortifications));
 			}
 		}
 		// Add characters, incl Cardinals
@@ -2376,7 +2379,6 @@ class World implements GoodwillProvider {
 		if (region.isLand() && NationData.isFriendly(region.getKingdom(), army.kingdom, this)) return false;
 		if (region.isLand() && tivar.deluge) return true;
 		if (region.type.equals("sea") && tivar.warwinds) return true;
-		if ("Pirate".equals(army.kingdom) && region.getKingdom() != null && getNation(region.getKingdom()).hasTag(NationData.Tag.DISCIPLINED)) return true;
 		return false;
 	}
 
@@ -2439,10 +2441,6 @@ class World implements GoodwillProvider {
 			if (getNation(target.getKingdom()).hasTag(NationData.Tag.NOMADIC)) {
 				targetUnrestFactor = 0.2;
 				fromUnrestFactor = 0.2;
-			}
-			for (String k : kingdoms.keySet()) if (getNation(k).hasTag(NationData.Tag.RUINED) && getNation(k).coreRegions.contains(regions.indexOf(target)) && !getNation(k).coreRegions.contains(regions.indexOf(from))) {
-				targetUnrestFactor = 0;
-				fromUnrestFactor = 0;
 			}
 			if (Ideology.CHALICE_OF_COMPASSION == getDominantIruhanIdeology()) {
 				if (target.religion.religion == Religion.IRUHAN) targetUnrestFactor = 0;

--- a/backend/src/test/java/com/empire/RegionTest.java
+++ b/backend/src/test/java/com/empire/RegionTest.java
@@ -159,7 +159,7 @@ public class RegionTest {
 	@Test
 	public void calcMinConquestStrengthStoic(){
 		when(n1.hasTag(NationData.Tag.STOIC)).thenReturn(true);
-		assertEquals(9.1875, r.calcMinConquestStrength(w), DELTA);
+		assertEquals(5.25 * 2.5, r.calcMinConquestStrength(w), DELTA);
 	}
 
 	@Test
@@ -172,6 +172,13 @@ public class RegionTest {
 	public void calcMinPatrolStrength(){
 		r.unrestPopular = 0.4;
 		assertEquals(3.3, r.calcMinPatrolStrength(w), DELTA);
+	}
+
+	@Test
+	public void calcMinPatrolStrengthDisciplined(){
+		r.unrestPopular = 0.4;
+		when(n1.hasTag(NationData.Tag.DISCIPLINED)).thenReturn(true);
+		assertEquals(1.8, r.calcMinPatrolStrength(w), DELTA);
 	}
 
 	@Test

--- a/frontend/gamelib.js
+++ b/frontend/gamelib.js
@@ -315,7 +315,7 @@ class Region {
 		let mods = [];
 		if (this.noble != undefined && contains(this.noble.tags, "Loyal")) mods.push({"v": 1, "unit": "%", "why": "Loyal Noble"});
 		if (this.noble != undefined && contains(this.noble.tags, "Desperate")) mods.push({"v": -2, "unit": "%", "why": "Desperate Noble"});
-		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Stoic")) mods.push({"v": .75, "unit": "%", "why": "Stoic Nation"});
+		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Stoic")) mods.push({"v": 1.5, "unit": "%", "why": "Stoic Nation"});
 		mods.push({"v": this.calcFortification().v - 1, "unit": "%", "why": "Fortification"});
 		// √(the population of the region) × the region’s fortification multiplier × (100% - the region’s unrest percentage) × 3
 		return Calc.moddedNum(
@@ -329,6 +329,7 @@ class Region {
 
 	calcMinPatrolSize() {
 		let mods = [];
+		if ("Unruled" != this.kingdom && contains(getNation(this.kingdom).tags, "Disciplined")) mods.push({"v": -.5, "unit": "%", "why": "Disciplined Nation"});
 		mods.push({"v": this.calcUnrest().v * 2 - 0.7, "unit": "%", "why": "Unrest"});
 		// √(the population of the region) × 3%
 		return Calc.moddedNum(

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -331,8 +331,8 @@
 				"Tavian (River of Kuun)": "Your people broadly believe that the duty of the fortunate is to provide for the unfortunate. Any feasts you throw will trigger economic activity and other nations will generate more income for sharing borders with you.",
 			};
 			let traitConsequences = {
-				"Defensive": "Your people are twice as effective at constructing fortifications.",
-				"Disciplined": "Your armies are more effective, and any pirates that enter your regions lose 25% of their strength.",
+				"Defensive": "You start with fortifications in each of your regions, and your people are twice as effective at constructing new fortifications.",
+				"Disciplined": "Your armies are more effective, and your regions are easier to patrol.",
 				"Evangelical": "Your people will fund the spreading of your state religion.",
 				"Heroic": "You control extra heroic characters.",
 				"Holy": "While your state ideology matches the dominant Iruhan ideology, the Church of Iruhan will donate about twice as much gold to you.",
@@ -344,7 +344,6 @@
 				"Patriotic": "Your nation starts with more soldiers and produces more recruits.",
 				"Rebellious": "All but one of the regions of your regions start controlled by your neighbors. You start with extra gold and armies. Your navies and armies within your rightful borders cost less to maintain.",
 				"Republican": "Your nation is a republic, not a kingdom. Popular unrest decreases in every one of your regions over time, but you cannot use feudal nobles.",
-				"Ruined": "You start with decreased population, but relocating population into your rightful regions does not cause any unrest and is not objectionable to the Church of Iruhan.",
 				"Seafaring": "You start with extra warships and gain more gold from sea regions than other nations do.",
 				"Ship-Building": "Whenever you construct a new shipyard, it immediately produces an extra small fleet of warships.",
 				"Stoic": "High unrest never decreases the size of the harvest in your regions, and your regions are more difficult for enemies to conquer.",


### PR DESCRIPTION
Defensive nations now start with extra fortifications.
Disciplined nations now find it easier to patrol their regions, rather than causing pirates attrition.
Ruined trait removed.
Stoic nations are now +150% as difficult to conquer.