### PR TITLE
Lobbying & Password Changes

### DIFF
--- a/backend/src/main/java/com/empire/Lobby.java
+++ b/backend/src/main/java/com/empire/Lobby.java
@@ -1,14 +1,11 @@
 package com.empire;
 
 import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.EmbeddedEntity;
-import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
-import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Text;
+import com.google.appengine.api.datastore.Query;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -18,43 +15,57 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class Lobby {
 	public static final String TYPE = "Lobby";
 
-	int numPlayers;
-	int ruleSet;
-	Schedule schedule;
-	Map<String, NationSetup> nations = new HashMap<>();
-	int minPlayers;
-	long startAt;
+	private long gameId;
+	private int numPlayers;
+	private int ruleSet;
+	private Schedule schedule;
+	private Map<String, NationSetup> nations = new HashMap<>();
+	private int minPlayers;
+	private long startAt;
 
 	private static Gson getGson() {
 		return new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
 	}
 
-	private static String loadJson(long gameId, DatastoreService service) throws EntityNotFoundException {
-		Entity e = service.get(KeyFactory.createKey(TYPE, "_" + gameId));
-		return new String(((Text)e.getProperty("json")).getValue());
+	private static Lobby fromEntity(Entity e) {
+		return getGson().fromJson(new String(((Text)e.getProperty("json")).getValue()), Lobby.class);
 	}
 
-	private static Lobby fromJson(String json) {
-		return getGson().fromJson(json, Lobby.class);
+	public static Stream<Lobby> loadAll(DatastoreService service) {
+		return StreamSupport.stream(service.prepare(new Query(Lobby.TYPE)).asIterable().spliterator(), false).map(e -> fromEntity(e));
 	}
 
 	public static Lobby load(long gameId, DatastoreService service) throws EntityNotFoundException {
-		return fromJson(loadJson(gameId, service));
+		return fromEntity(service.get(KeyFactory.createKey(TYPE, "_" + gameId)));
+	}
+
+	public void delete(DatastoreService service) {
+		service.delete(KeyFactory.createKey(TYPE, "_" + gameId));
 	}
 
 	public boolean update(String nation, NationSetup setup) {
 		return nations.putIfAbsent(nation, setup) == null;
 	}
 
-	public boolean canStart(Instant now) {
-		return nations.size() >= minPlayers && (nations.size() == numPlayers || now.toEpochMilli() >= startAt);
+	public enum StartResult {
+		WAIT,
+		START,
+		ABANDON
+	}
+	public StartResult canStart(Instant now) {
+		if (nations.size() == numPlayers) return StartResult.START;
+		if (now.toEpochMilli() < startAt) return StartResult.WAIT;
+		if (nations.size() >= minPlayers) return StartResult.START;
+		return StartResult.ABANDON;
 	}
 
-	public void save(long gameId, DatastoreService service) {
+	public void save(DatastoreService service) {
 		Entity lobby = new Entity(TYPE, "_" + gameId);
 		lobby.setProperty("json", new Text(getGson().toJson(this)));
 		service.put(lobby);
@@ -62,7 +73,8 @@ public class Lobby {
 
 	private Lobby() {} // For GSON.
 
-	private Lobby(int ruleSet, int numPlayers, Schedule schedule, int minPlayers, long startAt) {
+	private Lobby(long gameId, int ruleSet, int numPlayers, Schedule schedule, int minPlayers, long startAt) {
+		this.gameId = gameId;
 		this.ruleSet = ruleSet;
 		this.numPlayers = numPlayers;
 		this.schedule = schedule;
@@ -70,8 +82,12 @@ public class Lobby {
 		this.startAt = startAt;
 	}
 
-	public static Lobby newLobby(int ruleSet, int numPlayers, Schedule schedule, int minPlayers, long startAt) {
-		return new Lobby(ruleSet, numPlayers, schedule, minPlayers, startAt);
+	public static Lobby newLobby(long gameId, int ruleSet, int numPlayers, Schedule schedule, int minPlayers, long startAt) {
+		return new Lobby(gameId, ruleSet, numPlayers, schedule, minPlayers, startAt);
+	}
+
+	public long getGameId() {
+		return gameId;
 	}
 
 	public int getNumPlayers() {
@@ -84,6 +100,10 @@ public class Lobby {
 
 	public Map<String, NationSetup> getNations() {
 		return nations;
+	}
+
+	public Schedule getSchedule() {
+		return schedule;
 	}
 
 	@Override

--- a/backend/src/main/java/com/empire/World.java
+++ b/backend/src/main/java/com/empire/World.java
@@ -152,13 +152,13 @@ public class World extends RulesObject implements GoodwillProvider {
 	private static class RuleSet { int ruleSet; };
 
 	public static World startNew(Lobby lobby) throws IOException {
-		Map<String, NationSetup> nationSetup = lobby.nations;
-		World w = newWorld(Rules.loadRules(lobby.ruleSet));
-		w.ruleSet = lobby.ruleSet;
-		w.numPlayers = lobby.numPlayers;
+		Map<String, NationSetup> nationSetup = lobby.getNations();
+		World w = newWorld(Rules.loadRules(lobby.getRuleSet()));
+		w.ruleSet = lobby.getRuleSet();
+		w.numPlayers = lobby.getNumPlayers();
 		w.geography = Geography.loadGeography(w.ruleSet, w.numPlayers);
 		w.date = 1;
-		w.turnSchedule = lobby.schedule;
+		w.turnSchedule = lobby.getSchedule();
 		w.nextTurn = w.turnSchedule.getNextTimeFirstTurn();
 		w.regions = new ArrayList<>();
 		w.pirate.threat = 4;
@@ -2205,10 +2205,7 @@ public class World extends RulesObject implements GoodwillProvider {
 				}
 				destinations.removeIf(d -> d.unrestPopular >= r.unrestPopular);
 				destinations.removeIf(d -> starvingRegions.contains(d));
-				destinations.removeIf(d ->
-						!d.getKingdom().equals(r.getKingdom())
-						&& (patrolledRegions.contains(r)
-								|| getNation(d.getKingdom()).getRelationship(r.getKingdom()).refugees == Relationship.Refugees.REFUSE));
+				destinations.removeIf(d -> !d.getKingdom().equals(r.getKingdom()) && (patrolledRegions.contains(r) || getNation(d.getKingdom()).getRelationship(r.getKingdom()).refugees == Relationship.Refugees.REFUSE));
 				if (destinations.isEmpty() || eligibleToEmigrate < 1) continue;
 				double totalWeight = 0;
 				for (Region d : destinations) totalWeight += d.calcImmigrationWeight(World.this);

--- a/backend/src/main/java/com/empire/svc/EntryServlet.java
+++ b/backend/src/main/java/com/empire/svc/EntryServlet.java
@@ -81,7 +81,7 @@ TODO: Will eventually need a changePassword/change-email.
 public class EntryServlet extends HttpServlet {
 	private static final Logger log = Logger.getLogger(EntryServlet.class.getName());
 	private static final String PASSWORD_SALT = "~ Empire_Password Salt ~123`";
-	private static byte[] GM_PASSWORD_HASH = BaseEncoding.base16().decode("dfec33349f0ee2e0bc2085d761553bddf1753698ddad94491664f14ea58ea072");
+	private static byte[] GM_PASSWORD_HASH = BaseEncoding.base16().decode("DFEC33349F0EE2E0BC2085D761553BDDF1753698DDAD94491664F14EA58EA072");
 
 	@Override
 	public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -354,6 +354,7 @@ public class EntryServlet extends HttpServlet {
 					mail(addresses, "👑 Empire: Game Failed to Start", "A lobby of Empire that you were in didn't get enough players by the deadline and has expired.");
 					lobby.delete(service);
 				}
+				txn.commit();
 			} finally {
 				if (txn.isActive()) txn.rollback();
 			}

--- a/tools/kickoff.html
+++ b/tools/kickoff.html
@@ -21,7 +21,7 @@
 						"locale": "America/Los_Angeles"
 					},
 					"min_players": parseInt(document.getElementById("numPlayersMin").value),
-					"start_at_millis": new Date(document.getElementById("startDate")).getTime(),
+					"start_at_millis": new Date(document.getElementById("startAt").value).getTime(),
 				}));
 				return false;
 			}
@@ -39,6 +39,14 @@
 				return false;
 			}
 		</script>
+		<style>
+			body {
+				font-family: sans-serif;
+			}
+			label {
+				display: block;
+			}
+		</style>
 	</head>
 	<body>
 		<h1>Start Lobby</h1>

--- a/tools/kickoff.html
+++ b/tools/kickoff.html
@@ -19,27 +19,9 @@
 						"times": Array.from(document.getElementById("times").selectedOptions).map(e => parseInt(e.value)),
 						"days": Array.from(document.getElementById("daysOfWeek").selectedOptions).map(e => e.value),
 						"locale": "America/Los_Angeles"
-					}
-				}));
-				return false;
-			}
-
-			function postFormStartWorld() {
-				let pw = document.getElementById("gmPassword").value;
-				let pw2 = document.getElementById("obsPassword").value;
-				let gameId = parseInt(document.getElementById("gameId").value);
-				
-				let req = new XMLHttpRequest();
-				req.open("post", g_server + "/entry/startworld?gid=" + gameId, true);
-				req.onerror = function (e) {
-					window.alert(req.status);
-				};
-				req.onload = function (ev) {
-					window.alert(req.status);
-				};
-				req.send(JSON.stringify({
-					"gm_password": pw,
-					"obs_password": pw2
+					},
+					"min_players": parseInt(document.getElementById("numPlayersMin").value),
+					"start_at_millis": new Date(document.getElementById("startDate")).getTime(),
 				}));
 				return false;
 			}
@@ -63,6 +45,7 @@
 		<form onsubmit="return postFormStartLobby();">
 			<label>Game ID: <input id="gameIdLobby" type="number" value="0"/></label>
 			<label>Number of Players: <input id="numPlayers" type="number" value="26"/></label>
+			<label>Minimum Number of Players: <input id="numPlayersMin" type="number" value="26"/></label>
 			<label>Days Of Week: <select id="daysOfWeek" multiple>
 				<option>MONDAY</option>
 				<option>TUESDAY</option>
@@ -73,14 +56,8 @@
 				<option>SUNDAY</option>
 			</select></label>
 			<label>Time(s) (America/Los_Angeles): <select id="times" multiple></select></label>
+			<label>Start At (Local Time): <input id="startAt" type="datetime-local" value=""/></label>
 			<button>Create Lobby</button>
-		</form>
-		<h1>Start Game</h1>
-		<form onsubmit="return postFormStartWorld();">
-			<label>GM Password: <input id="gmPassword" type="password"/></label>
-			<label>Observer Password: <input id="obsPassword" type="password"/></label>
-			<label>Game ID: <input id="gameId" type="number"/></label>
-			<button>Start</button>
 		</form>
 		<h1>Trigger Server-Side Migration</h1>
 		<form onsubmit="return postFormMigrate();">

--- a/tools/localtest.html
+++ b/tools/localtest.html
@@ -8,24 +8,6 @@
 
 			function finalize() {
 				commitCount--;
-				if (commitCount > 0) return;
-
-				let gameId = parseInt(document.getElementById("gameId").value);
-				let req = new XMLHttpRequest();
-				req.open("post", g_server + "/entry/startworld?gid=" + gameId, true);
-				req.onerror = function (e) {
-					window.alert(req.status);
-				};
-				req.onload = function (ev) {
-					window.alert(req.status);
-				};
-				let ns = [];
-				for (let n in nations) ns.push(capitalize(n));
-				req.send(JSON.stringify({
-					"gm_password": "gm",
-					"obs_password": "obs",
-					"kingdoms": ns
-				}));
 			}
 
 			function postForm() {
@@ -46,7 +28,9 @@
 							"days": ["MONDAY", "WEDNESDAY", "FRIDAY"],
 							"times": [180],
 							"locale": "America/Los_Angeles"
-						}
+						},
+						"min_players": numPlayers,
+						"start_at_millis": Date.now() + 60000,
 					}));
 				}
 				return false;


### PR DESCRIPTION
 • Per-game GM passwords have been removed, but a global one has been added. (This is an intermediate step in eliminating the GM and Observer roles entirely. Eventually the global GM role will also go away.)
 • Game lobbies now have a target start datetime and minimum player number. If they've reached the minimum number of players by that time, they will kick themselves off and self-delete. If they haven't, they will self-delete. They will start early if they fill up.