### PR TITLE
Execute character actions before noble and travel orders.

### DIFF
--- a/backend/src/main/java/com/empire/World.java
+++ b/backend/src/main/java/com/empire/World.java
@@ -603,9 +603,9 @@ public class World extends RulesObject implements GoodwillProvider {
 			doctrineChanges();
 			orderOverrides();
 			armyActionsNonTravel();
+			characterActions();
 			armyActionsTravel();
 			nobleActions();
-			characterActions();
 			spawnCultists();
 			bribePirates();
 			spawnPirates();


### PR DESCRIPTION
Moving character actions before nobles as r12 rules

```
- All other unit orders resolved.
        Non-travel army/navy orders
        Non-travel character orders
        Travel orders
        Noble orders
```